### PR TITLE
Add delay support before reloading the browser.

### DIFF
--- a/http-watcher.go
+++ b/http-watcher.go
@@ -43,6 +43,7 @@ type ReloadMux struct {
 	proxy         int
 	monitor       bool
 	fsWatcher     *fsnotify.Watcher
+	delay         float64
 }
 
 var reloadCfg = ReloadMux{
@@ -340,7 +341,7 @@ func notifyBrowsers() {
 		defer c.conn.Close()
 		reload := "HTTP/1.1 200 OK\r\n"
 		reload += "Cache-Control: no-cache\r\nContent-Type: text/javascript\r\n\r\n"
-		reload += "location.reload(true);"
+		reload += fmt.Sprintf("setTimeout(function(){location.reload(true)}, %f*1000);", reloadCfg.delay)
 		c.buf.Write([]byte(reload))
 		c.buf.Flush()
 	}
@@ -425,6 +426,7 @@ func main() {
 	flag.BoolVar(&(reloadCfg.private), "private", false, "Only listen on lookback interface, otherwise listen on all interface")
 	flag.IntVar(&(reloadCfg.proxy), "proxy", 0, "Local dynamic site's port number, like 8080, HTTP watcher proxy it, automatically reload browsers when watched directory's file changed")
 	flag.BoolVar(&(reloadCfg.monitor), "monitor", true, "Enable monitor filesystem event")
+	flag.Float64Var(&(reloadCfg.delay), "delay", 0, "Delay in seconds before reload browser.")
 	flag.Parse()
 
 	if _, e := os.Open(reloadCfg.command); e == nil {


### PR DESCRIPTION
Hi Shenfeng,

虽然这个是方便前端用的，但是配合后端开发也很棒啊。只是如果没有延时，刷新的时候可能服务器程序还没完成重启，这样看到的还是老页面或者遇到connection refused。

这个patch加了简单的设置延时的功能。这样就可以配合nodemon或者rerun等各种第三方reload程序使用。

lsm
