### PR TITLE
Check shouldIgnore() before adding event

### DIFF
--- a/http-watcher.go
+++ b/http-watcher.go
@@ -411,7 +411,9 @@ func processFsEvents() {
 						reloadCfg.fsWatcher.Watch(ev.Name)
 					}
 				} else {
-					events = append(events, ev)
+					if !shouldIgnore(ev.Name) {
+						events = append(events, ev)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I would like to ignore `.swp` files created by Vim editor, however specifying `-ignores ".*swp$"` has no effect. This pull request fixes that.
